### PR TITLE
Make the package buildable with the latest GHC and dependency libraries

### DIFF
--- a/Network/HTTP/Server.hs
+++ b/Network/HTTP/Server.hs
@@ -122,14 +122,15 @@ serverWith conf handler = withSocketsDo $
 
 
   client sock addr =
-    do let name = ppSockAddr addr ""
-       logInfo lg 0 ("Accepted connection from " ++ name)
-       conn <- socketConnection name sock    -- XXX: name?
+    do let client_host = ppHostAddr addr
+       let portnum = portFromSockAddr addr
+       let client_addr = ppSockAddr addr ""    
+       logInfo lg 0 ("Accepted connection from " ++ client_addr)
+       conn <- socketConnection client_host portnum sock
        setStreamHooks conn nullHooks { hook_close =
-          logInfo lg 0 ("Closing  connection to " ++ ppSockAddr addr "")
+          logInfo lg 0 ("Closing  connection to " ++ client_addr)
              }
        client_interact addr conn
-
 
   -- client_interact :: SockAddr -> HandleStream a -> IO ()
   client_interact addr conn =

--- a/Network/HTTP/Server/Utils.hs
+++ b/Network/HTTP/Server/Utils.hs
@@ -54,3 +54,23 @@ ppSockAddr (SockAddrInet6 port _ addr _) =
   ppHostAddress6 addr . showChar ':' . shows port
 ppSockAddr (SockAddrUnix sock) = showString "unix/" . showString sock
 #endif
+
+-- |Extract the host address from a SockAddr and pretty print
+ppHostAddr :: SockAddr -> String
+ppHostAddr (SockAddrInet _ addr) = ppHostAddress addr ""
+#ifdef _OS_UNIX
+ppHostAddr (SockAddrInet6 _ _ addr _) = ppHostAddress6 addr ""
+ppHostAddr a@(SockAddrUnix _) = ppSockAddr a ""
+#endif
+
+-- |Extract the port number from a SockAddr
+portFromSockAddr :: SockAddr -> Int
+portFromSockAddr (SockAddrInet port _) = fromInteger $ toInteger port
+#ifdef _OS_UNIX
+portFromSockAddr (SockAddrInet6 port _ _ _) = fromInteger $ toInteger port
+portFromSockAddr (SockAddrUnix _) = -1 -- according to documentation
+                                       -- of Network.accept, "When
+                                       -- using AF_UNIX, HostName will
+                                       -- be set to the path of the
+                                       -- socet and PortNumber of -1.
+#endif

--- a/http-server.cabal
+++ b/http-server.cabal
@@ -31,7 +31,7 @@ library
     UndecidableInstances
 
   build-depends:
-    HTTP        >= 4000.0.7 && < 5000,
+    HTTP        >= 4000.2.0 && < 5000,
     base        >= 4        && < 5,
     mime        >= 0.3      && < 2,
     network     >= 2        && < 3,


### PR DESCRIPTION
HTTP-4000.2.0 broke the API in Network.TCP by changing the type signature of socketConnection. This caused the build to fail in Server.hs. The attached commit provides a work-around consistent with the network library (the main thing was providing a dummy port number (-1) for Unix socket connections that don't have a port number by definition).
