### PR TITLE
Fix Content-Type in example.

### DIFF
--- a/example/SimpleWeb.hs
+++ b/example/SimpleWeb.hs
@@ -80,8 +80,7 @@ main = serverWith defaultConfig { srvLog = stdLogger, srvPort = 8888 }
 
 sendText       :: StatusCode -> String -> Response String
 sendText s v    = insertHeader HdrContentLength (show (length txt))
-                $ insertHeader HdrContentEncoding "UTF-8"
-                $ insertHeader HdrContentEncoding "text/plain"
+                $ insertHeader HdrContentType "text/plain; charset=utf-8"
                 $ (respond s :: Response String) { rspBody = txt }
   where txt       = encodeString v
 


### PR DESCRIPTION
Fix
1. A small typo where you meant ContentType but entered ContentEncoding
2. I guess [reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) people usually put UTF-8 in Content-Type like this and put compression scheme in ContentEncoding